### PR TITLE
Update readme and set vuetify as nondev module

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@
 - Add `@nuxtjs/vuetify@next` dependency to your project
 
 ```bash
-npm install --save-dev @nuxtjs/vuetify@next # or yarn add --dev @nuxtjs/vuetify@next
+npm install --save @nuxtjs/vuetify@next # or yarn add @nuxtjs/vuetify@next
 ```
 
-- Add `@nuxtjs/vuetify` to `devModules` section of your `nuxt.config.js`
+- Add `@nuxtjs/vuetify` to `modules` section of your `nuxt.config.js`
 
 ```js
 {
-  devModules: [
+  modules: [
     '@nuxtjs/vuetify'
   ],
 


### PR DESCRIPTION
As vuetify is used in production as well, the `devModules` section in the nuxt config is the wrong place.