### PR TITLE
feat: manual import

### DIFF
--- a/lib/templates/plugin.js
+++ b/lib/templates/plugin.js
@@ -1,8 +1,40 @@
 import Vue from 'vue'
-import Vuetify from '<%= options.treeShake ? 'vuetify/lib' : 'vuetify' %>'
 import options from './options'
+<%
+// handle manual imports
+const componentImports = typeof options.treeShake === 'object' && Array.isArray(options.treeShake.components)
+  ? options.treeShake.components.filter(c => typeof c === 'string')
+  : []
+const transitionImports = typeof options.treeShake === 'object' && Array.isArray(options.treeShake.transitions)
+  ? options.treeShake.transitions.filter(t => typeof t === 'string')
+  : []
+const directiveImports = typeof options.treeShake === 'object' && Array.isArray(options.treeShake.directives)
+  ?  options.treeShake.directives.filter(d => typeof d === 'string')
+  : []
+const libImports = componentImports.concat(transitionImports)
+%>
+import Vuetify<% if (libImports.length > 0) { %>, {
+  <%= libImports.join(',\n  ') %>
+}<% } %> from '<%= options.treeShake ? 'vuetify/lib' : 'vuetify' %>'
+<% if (directiveImports.length > 0) { %>
+import { directiveImports.join(', ') } from 'vuetify/lib/directives'
+<% } %>
 
-Vue.use(Vuetify)
+Vue.use(Vuetify<% if (componentImports.length > 0 || transitionImports.length > 0 || directiveImports.length > 0) { %>, {
+  <%
+  const vuetifyUseOptions = []
+  if (componentImports.length > 0) {
+    vuetifyUseOptions.push('components: { ' + componentImports.join(', ') + ' }')
+  }
+  if (directiveImports.length > 0) {
+    vuetifyUseOptions.push('directives: { ' + directiveImports.join(', ') + ' }')
+  }
+  if (transitionImports.length > 0) {
+    vuetifyUseOptions.push('transitions: { ' + transitionImports.join(', ') + ' }')
+  }
+  print(vuetifyUseOptions.join(',\n  '))
+  %>
+}<% } %>)
 
 export default (ctx) => {
   const vuetifyOptions = typeof options === 'function' ? options(ctx) : options

--- a/test/fixture/pages/manual-import.vue
+++ b/test/fixture/pages/manual-import.vue
@@ -1,0 +1,12 @@
+<template>
+  <v-container>
+    <v-layout>
+      <v-flex>
+        <!-- eslint-disable-next-line vue/require-component-is -->
+        <component is="v-chip">
+          Default
+        </component>
+      </v-flex>
+    </v-layout>
+  </v-container>
+</template>

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -99,3 +99,29 @@ describe.skip('enable treeShake', () => {
     expect(html).toContain('v-navigation-drawer--fixed')
   })
 })
+
+describe.skip('manually import', () => {
+  let nuxt
+
+  beforeAll(async () => {
+    nuxt = new Nuxt({
+      ...config,
+      vuetify: {
+        treeShake: {
+          components: ['VChip']
+        }
+      }
+    })
+    await nuxt.ready()
+    await new Builder(nuxt).build()
+  })
+
+  afterAll(async () => {
+    await nuxt.close()
+  })
+
+  test('render', async () => {
+    const { html } = await nuxt.renderRoute('/manual-import')
+    expect(html).toContain('v-chip__content')
+  })
+})


### PR DESCRIPTION
Related : #109 

A proposal for the implementation of manually importing feature

The configuration of this uses [`treeShake`](https://github.com/nuxt-community/vuetify-module#treeshake) attribute as manually importing is closely related to tree-shaking. `treeShake` now accepts: 
* `false` (no tree-shaking), 
* `true` (enables tree-shaking but no manual imports), or,
* an `object` with `components`, `directives` and/or `transitions` properties, each of the property is optional and accepts an `array` of `string`s of the element names that are being imported (enables tree-shaking and manually importing): 
```
{
  components: [
    'VCard',
    'VRating',
    'VToolbar'
  ],
  directives: [
    'Ripple'
  ],
  transitions: [
    'VFadeTransition'
  ]
}
```