### PR TITLE
feat(types): provide nuxt 2.9 compatible types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,3 +5,10 @@ declare module '@nuxt/vue-app' {
     $vuetify: VuetifyObject
   }
 }
+
+// Nuxt 2.9+
+declare module '@nuxt/types' {
+  interface Context {
+    $vuetify: VuetifyObject
+  }
+}


### PR DESCRIPTION
Since Nuxt 2.9, types are defined around @nuxt/types packages.
These changes make the module types work with Nuxt 2.9 new TypeScript specs.