### PR TITLE
fix: remove duplicate import of main.sass

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -54,9 +54,7 @@ module.exports = function (moduleOptions) {
     }
 
     // Add styles
-    if (options.treeShake) {
-      this.options.css.push('vuetify/src/styles/main.sass')
-    } else {
+    if (!options.treeShake) {
       this.options.css.push('vuetify/dist/vuetify.css')
     }
 


### PR DESCRIPTION
main.sass is already imported by vuetify in [vuetify/src/framework.ts](https://github.com/vuetifyjs/vuetify/blob/668025e76d602313ed431ef3c1fc612924ff60a3/packages/vuetify/src/framework.ts#L15)