### PR TITLE
chore(deps): update dependency sass-loader to v8

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -20,10 +20,11 @@ const cdn = {
   'fa4': 'https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css'
 }
 
-// See https://github.com/vuetifyjs/vuetify/releases/tag/v2.0.0-alpha.12
 const sassLoaderOptions = {
   implementation: require('sass'),
-  fiber: require('fibers')
+  sassOptions: {
+    indentedSyntax: true
+  }
 }
 
 module.exports = function (moduleOptions) {
@@ -42,15 +43,20 @@ module.exports = function (moduleOptions) {
       }
     }
 
+    // Ensure sass-loader@8 compatibility (https://github.com/webpack-contrib/sass-loader/releases/tag/v8.0.0)
+    delete this.options.build.loaders.sass.indentedSyntax
+    this.options.build.loaders.sass.prependData = this.options.build.loaders.sass.data
+    delete this.options.build.loaders.sass.data
+
     // Customize sass-loader options
     Object.assign(this.options.build.loaders.scss, sassLoaderOptions)
     Object.assign(this.options.build.loaders.sass, sassLoaderOptions)
 
     // Custom variables
-    const sassLoaderData = this.options.build.loaders.sass.data
+    const sassLoaderData = this.options.build.loaders.sass.prependData
     if (options.customVariables.length > 0 && typeof sassLoaderData !== 'function') {
       const imports = options.customVariables.map(path => `@import '${path}'`).join('\n')
-      this.options.build.loaders.sass.data = sassLoaderData ? sassLoaderData.concat('\n', imports) : imports
+      this.options.build.loaders.sass.prependData = sassLoaderData ? sassLoaderData.concat('\n', imports) : imports
     }
 
     // Add styles

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "deepmerge": "^4.0.0",
     "fibers": "^4.0.1",
     "sass": "^1.22.10",
-    "sass-loader": "^7.3.1",
+    "sass-loader": "^8.0.0",
     "vuetify": "^2.0.11",
     "vuetify-loader": "^1.3.0"
   },

--- a/test/module.test.js
+++ b/test/module.test.js
@@ -73,7 +73,7 @@ describe('module', () => {
       }
     })
 
-    expect(nuxt.options.build.loaders.sass.data).toContain("@import '/path/to/variables.scss'")
+    expect(nuxt.options.build.loaders.sass.prependData).toContain("@import '/path/to/variables.scss'")
   })
 
   test('with treeShake', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6174,7 +6174,7 @@ loader-utils@^0.2.16:
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
-loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.0, loader-utils@^1.2.3:
+loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.0, loader-utils@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -8809,15 +8809,15 @@ sane@^4.0.3:
     minimist "^1.1.1"
     walker "~1.0.5"
 
-sass-loader@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
-  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
+sass-loader@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-8.0.0.tgz#e7b07a3e357f965e6b03dd45b016b0a9746af797"
+  integrity sha512-+qeMu563PN7rPdit2+n5uuYVR0SSVwm0JsOUsaJXzgYcClWSlmX0iHDnmeOobPkf5kUglVot3QS6SyLyaQoJ4w==
   dependencies:
     clone-deep "^4.0.1"
-    loader-utils "^1.0.1"
-    neo-async "^2.5.0"
-    pify "^4.0.1"
+    loader-utils "^1.2.3"
+    neo-async "^2.6.1"
+    schema-utils "^2.1.0"
     semver "^6.3.0"
 
 sass@^1.22.10:
@@ -8841,7 +8841,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0:
+schema-utils@^2.0.0, schema-utils@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.1.0.tgz#940363b6b1ec407800a22951bdcc23363c039393"
   integrity sha512-g6SViEZAfGNrToD82ZPUjq52KUPDYc+fN5+g6Euo5mLokl/9Yx14z0Cu4RR1m55HtBXejO0sBt+qw79axN+Fiw==


### PR DESCRIPTION
https://github.com/webpack-contrib/sass-loader/releases/tag/v8.0.0

Some changes have been made to follow the following breaking changes and features
> move all sass (includePaths, importer, functions) options to the **sassOptions** option

> the **data** option was renamed to the **prependData** option

> automatically use the **fibers** package if it is possible 

> validate loader options