### PR TITLE
Fix error when import lang module

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -12,7 +12,7 @@ export default function setupBuild (this: ModuleThis, options: Options) {
   if (options.treeShake) {
     const VuetifyLoaderPlugin = this.nuxt.resolver.requireModule('vuetify-loader/lib/plugin')
 
-    this.options.build!.transpile!.push('vuetify/lib')
+    this.options.build!.transpile!.push('vuetify')
 
     this.extendBuild((config) => {
       config.plugins!.push(new VuetifyLoaderPlugin(typeof options.treeShake === 'object' ? options.treeShake.loaderOptions : {}))

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -130,7 +130,7 @@ describe('setupBuild', () => {
       treeShake: true
     })
 
-    expect(nuxt.options.build.transpile).toContain('vuetify/lib')
+    expect(nuxt.options.build.transpile).toContain('vuetify')
     expect(VuetifyLoaderPlugin).toHaveBeenCalled()
   })
 
@@ -147,7 +147,7 @@ describe('setupBuild', () => {
       }
     })
 
-    expect(nuxt.options.build.transpile).toContain('vuetify/lib')
+    expect(nuxt.options.build.transpile).toContain('vuetify')
     expect(VuetifyLoaderPlugin).toHaveBeenCalledWith(loaderOptions)
   })
 })


### PR DESCRIPTION
The transpile of webpack need be `'vuetify'` or the regex `/^vuetify/`

Issue: https://github.com/nuxt-community/vuetify-module/issues/198

Are you need look where i took the fixes?, look the repo of vuetify for vue-cli: https://github.com/vuetifyjs/vue-cli-plugin-vuetify/blob/master/packages/vue-cli-plugin-vuetify/generator/tools/vuetify.js#L75