### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ Usage example :
 $btn-border-radius: 0px;
 
 // If you need to extend Vuetify SASS lists
+$material-light: ( cards: blue );
+
 @import '~vuetify/src/styles/styles.sass';
-$material-light: map-merge($material-light, ( cards: blue ));
 ```
 
 ```js


### PR DESCRIPTION
I thought it was a core error, but testing and testing I see the problem is not in the core.

The problem is the example, I thought create a warning (https://github.com/nuxt-community/vuetify-module/issues/228), but i see the code of vue-cli-plugin and this plugins append the styles.sass in the bottom of all prependData.

https://github.com/vuetifyjs/vue-cli-plugin-vuetify/blob/master/packages/vue-cli-plugin-vuetify/util/helpers.js#L47