### PR TITLE
fix: use minimal vuetify import

### DIFF
--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import Vuetify from '<%= options.treeShake ? 'vuetify/lib' : 'vuetify' %>'
+import Vuetify from '<%= options.treeShake ? 'vuetify/lib/framework' : 'vuetify' %>'
 <% if (options.preset) { %>
 import { preset } from '<%= options.preset %>'
 <% } %>


### PR DESCRIPTION
As described in https://vuetifyjs.com/en/customization/sass-variables#compilation-time, avoids compiling the entirety of vuetify if only a few components are used. #125 will still work but will negate any performance improvement. 