### PR TITLE
fix: fix VuetifyLoaderOptions match type

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -20,7 +20,7 @@ export interface VuetifyLoaderOptions {
     camelTag: string,
     path: string,
     component: SFCDescriptor
-  }): Array<[string, string]>
+  }): [string, string] | undefined
 }
 
 export interface Options extends Partial<VuetifyPreset> {

--- a/test/module.test.ts
+++ b/test/module.test.ts
@@ -137,7 +137,7 @@ describe('setupBuild', () => {
   test('treeShake with loaderOptions', () => {
     const loaderOptions: VuetifyLoaderOptions = {
       match () {
-        return []
+        return ['foo', 'bar']
       }
     }
 


### PR DESCRIPTION
According to [vuetify docs](https://vuetifyjs.com/en/customization/a-la-carte#vuetify-loader) match function optionally returns a tuple rather than an array of tuples.