### PR TITLE
Fix CDN link for Material Design icons(Specific version 5.0.45 -> 4.9…

### DIFF
--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,7 +1,7 @@
 import { ModuleThis } from '@nuxt/types/config/module'
 
 const presetsCDN = {
-  mdi: 'https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css',
+  mdi: 'https://cdnjs.cloudflare.com/ajax/libs/MaterialDesign-Webfont/4.9.95/css/materialdesignicons.min.css',
   md: 'https://fonts.googleapis.com/css?family=Material+Icons',
   fa: 'https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@latest/css/all.min.css',
   fa4: 'https://cdn.jsdelivr.net/npm/font-awesome@4.7.0/css/font-awesome.min.css'


### PR DESCRIPTION
The latest version of the material icon is now causing a lot of bugs.(v5.0.45)
[https://cdnjs.com/libraries/MaterialDesign-Webfont/5.0.45](https://cdnjs.com/libraries/MaterialDesign-Webfont/5.0.45)

We have to change LTS specific version(v4.9.95)

Associated issue: [https://github.com/vuetifyjs/vuetify/issues/10797](https://github.com/vuetifyjs/vuetify/issues/10797)