### PR TITLE
fix: update v-content to v-main for vuetify 2.3.0

### DIFF
--- a/test/fixture/layouts/default.vue
+++ b/test/fixture/layouts/default.vue
@@ -64,9 +64,9 @@
         />
       </v-layout>
     </v-app-bar>
-    <v-content>
+    <v-main>
       <Nuxt />
-    </v-content>
+    </v-main>
   </v-app>
 </template>
 


### PR DESCRIPTION
Change `v-content` to `v-main`

Vuetify version: [v2.3.0](https://github.com/vuetifyjs/vuetify/releases/tag/v2.3.0)

