### PR TITLE
fix(types): use UserVuetifyPreset instead of VuetifyPreset

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -23,7 +23,7 @@ export interface VuetifyLoaderOptions {
   }): [string, string] | undefined
 }
 
-export interface Options extends UserVuetifyPreset {
+export interface Options extends Omit<UserVuetifyPreset, 'preset'> {
   customVariables?: string[]
   defaultAssets?: {
     font?: FontOptions,

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,7 +1,7 @@
 import merge from 'deepmerge'
 
 import { SFCDescriptor } from 'vue-template-compiler'
-import { VuetifyPreset } from 'vuetify/types/services/presets'
+import { UserVuetifyPreset } from 'vuetify/types/services/presets'
 import { ModuleThis } from '@nuxt/types/config/module'
 
 import { FontOptions } from './font'
@@ -23,7 +23,7 @@ export interface VuetifyLoaderOptions {
   }): [string, string] | undefined
 }
 
-export interface Options extends Partial<VuetifyPreset> {
+export interface Options extends UserVuetifyPreset {
   customVariables?: string[]
   defaultAssets?: {
     font?: FontOptions,


### PR DESCRIPTION
VuetifyPreset requires all values to be set

> I'm using it with typescript and is it really necessary to put in all those options even I might be using the default one
![image](https://user-images.githubusercontent.com/16421948/107615407-413cc180-6ca0-11eb-9763-77db364a4dc0.png)
