### PR TITLE
fix(deps): revert to sass-loader v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "sass": "~1.32.13",
-    "sass-loader": "^12.3.0",
+    "sass-loader": "^10.2.0",
     "vuetify": "^2.6",
     "vuetify-loader": "^1.7.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9618,13 +9618,16 @@ sass-loader@10.1.1:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-sass-loader@^12.3.0:
-  version "12.3.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-12.3.0.tgz#93278981c189c36a58cbfc37d4b9cef0cdc02871"
-  integrity sha512-6l9qwhdOb7qSrtOu96QQ81LVl8v6Dp9j1w3akOm0aWHyrTYtagDt5+kS32N4yq4hHk3M+rdqoRMH+lIdqvW6HA==
+sass-loader@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-10.2.0.tgz#3d64c1590f911013b3fa48a0b22a83d5e1494716"
+  integrity sha512-kUceLzC1gIHz0zNJPpqRsJyisWatGYNFRmv2CKZK2/ngMJgLqxTbXwe/hJ85luyvZkgqU3VlJ33UVF2T/0g6mw==
   dependencies:
     klona "^2.0.4"
+    loader-utils "^2.0.0"
     neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    semver "^7.3.2"
 
 sass@~1.32.13:
   version "1.32.13"


### PR DESCRIPTION
Reverts nuxt-community/vuetify-module#453


sass-loader v12 is causing problem as nuxt@2 is using webpack 4 and sass-loader 10