### PR TITLE
fix(docs): update typescript installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ If you're using TypeScript, you'll need to add `@nuxtjs/vuetify` in your `compil
   "compilerOptions": {
     "types": [
       "@types/node",
-      "@nuxt/vue-app",
+      "@nuxt/types",
       "@nuxtjs/vuetify"
     ]
   }


### PR DESCRIPTION
`@nuxt/vue-app` got replaced with `@nuxt/types` since Nuxt.js 2.9.0.